### PR TITLE
Set Returned Qty ZERO

### DIFF
--- a/ModelLibrary/Model/MOrder.cs
+++ b/ModelLibrary/Model/MOrder.cs
@@ -1301,6 +1301,8 @@ namespace VAdvantage.Model
                     if (line.Get_ColumnIndex("C_Order_Quotation") > 0)
                         line.Set_Value("C_Order_Quotation", fromLines[i].GetC_Order_ID());
 
+                    // JID_0416 If we create SO/PO by using "Copy From" process system update return qty on new order.. we set this ZERO When we copy any order
+                    line.SetQtyReturned(I_ZERO);
                     line.SetQtyDelivered(Env.ZERO);
                     line.SetQtyInvoiced(Env.ZERO);
                     line.SetQtyReserved(Env.ZERO);


### PR DESCRIPTION
JID_0416 If we create SO/PO by using "Copy From" process system update return qty on new order.. we set this ZERO When we copy any order