### PR TITLE
removed "Error" word from log.SaveError() in MPayment and MPaymentAll…

### DIFF
--- a/ModelLibrary/Model/MPayment.cs
+++ b/ModelLibrary/Model/MPayment.cs
@@ -924,7 +924,9 @@ namespace VAdvantage.Model
                 {
                     if (string.IsNullOrEmpty(GetCheckNo()))
                     {
-                        log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        //"Error" not required
+                        //log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        log.SaveError("", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
                         return false;
                     }
                 }
@@ -1026,12 +1028,16 @@ namespace VAdvantage.Model
                 {
                     if (docBaseType.Equals(MDocBaseType.DOCBASETYPE_APPAYMENT) && GetCheckNo() == null)
                     {
-                        log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        //"Error" not required
+                        //log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        log.SaveError("", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
                         return false;
                     }
                     else if (docBaseType.Equals(MDocBaseType.DOCBASETYPE_ARRECEIPT) && GetCheckNo() == null)
                     {
-                        log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        //"Error" not required
+                        //log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        log.SaveError("", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
                         return false;
                     }
 
@@ -1042,13 +1048,17 @@ namespace VAdvantage.Model
                     // if AP Pay and payamt less than 0
                     if (docBaseType.Equals(MDocBaseType.DOCBASETYPE_APPAYMENT) && GetPayAmt() < 0 && GetCheckNo() == null)
                     {
-                        log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        //"Error" not required
+                        //log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        log.SaveError("", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
                         return false;
                     }
                     // if AR Rec and payamt greater than 0
                     else if (docBaseType.Equals(MDocBaseType.DOCBASETYPE_ARRECEIPT) && GetPayAmt() >= 0 && GetCheckNo() == null)
                     {
-                        log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        //"Error" not required
+                        //log.SaveError("Error", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
+                        log.SaveError("", Msg.GetMsg(GetCtx(), "EnterCheckNo"));
                         return false;
                     }
 

--- a/ModelLibrary/Model/MPaymentAllocate.cs
+++ b/ModelLibrary/Model/MPaymentAllocate.cs
@@ -352,7 +352,9 @@ namespace VAdvantage.Model
                 if (Util.GetValueOfInt(DB.ExecuteScalar("SELECT COUNT(*) FROM C_PaymentAllocate   WHERE C_Payment_ID = " + GetC_Payment_ID() +
                           @" AND IsActive = 'Y' AND C_InvoicePaySchedule_ID = " + GetC_InvoicePaySchedule_ID(), null, Get_Trx())) > 0)
                 {
-                    log.SaveError("Error", Msg.GetMsg(GetCtx(), "VIS_NotSaveDuplicateRecord"));
+                    //"Error" not required
+                    //log.SaveError("Error", Msg.GetMsg(GetCtx(), "VIS_NotSaveDuplicateRecord"));
+                    log.SaveError("", Msg.GetMsg(GetCtx(), "VIS_NotSaveDuplicateRecord"));
                     return false;
                 }
             }


### PR DESCRIPTION
Removed "Error" word from log.SaveError() in MPayment and MPaymentAllocate.cs files for 'VIS_NotSaveDuplicateRecord' and 'EnterCheckNo' Keys.