### PR TITLE
1. Handled Void AR Receipt Payment with  VA026_TRLoanApplication_ID>0…

### DIFF
--- a/ModelLibrary/Model/MPayment.cs
+++ b/ModelLibrary/Model/MPayment.cs
@@ -5037,6 +5037,19 @@ namespace VAdvantage.Model
                 SetWriteOffAmt(Env.ZERO);
                 SetOverUnderAmt(Env.ZERO);
                 SetIsAllocated(false);
+
+                //If Payment have VA026_TRLoanApplication_ID is present at that time Update C_Payment_ID as null in 
+                //VA026_TRLoanApplication window.
+                if (Env.IsModuleInstalled("VA026_"))
+                {
+                    // de allocate link from TR Loan Application when TR Loan Application ID > 0
+                    if (Get_ValueAsInt("VA026_TRLoanApplication_ID") > 0)
+                    {
+                        DB.ExecuteQuery("UPDATE VA026_TRLoanApplication SET  C_Payment_ID = null WHERE C_Payment_ID = " + GetC_Payment_ID() +
+                                        @" AND VA026_TRLoanApplication_ID = " + Get_ValueAsInt("VA026_TRLoanApplication_ID"), null, null);
+                    }
+                }
+
                 //	Unlink & De-Allocate
                 DeAllocate();
             }

--- a/VIS/Areas/VIS/Models/PaymentAllocation.cs
+++ b/VIS/Areas/VIS/Models/PaymentAllocation.cs
@@ -3133,7 +3133,8 @@ namespace VIS.Models
                     VIS_PaymentData pData = new VIS_PaymentData();
                     pData.SelectRow = "false";
                     pData.PaymentRecord = countRecord;
-                    pData.Date1 = dr.Tables[0].Rows[i]["DATE1"].ToString();
+                    // Converted into DateTime to handle in Central America TimeZone.
+                    pData.Date1 = Util.GetValueOfDateTime(dr.Tables[0].Rows[i]["DATE1"]);
                     pData.Documentno = dr.Tables[0].Rows[i]["DOCUMENTNO"].ToString();
                     pData.CpaymentID = dr.Tables[0].Rows[i]["CPAYMENTID"].ToString();
                     pData.Isocode = dr.Tables[0].Rows[i]["ISOCODE"].ToString();
@@ -3706,7 +3707,8 @@ currencyConvert(invoiceOpen * MultiplierAP, C_Currency_ID, " + _C_Currency_ID + 
                     VIS_InvoiceData pData = new VIS_InvoiceData();
                     pData.SelectRow = "false";
                     pData.InvoiceRecord = countRecord;
-                    pData.Date1 = dr.Tables[0].Rows[i]["DATE1"].ToString();
+                    // Converted into DateTime to handle in Central America TimeZone.
+                    pData.Date1 = Util.GetValueOfDateTime(dr.Tables[0].Rows[i]["DATE1"]);
                     pData.Documentno = dr.Tables[0].Rows[i]["DOCUMENTNO"].ToString();
                     pData.CinvoiceID = dr.Tables[0].Rows[i]["CINVOICEID"].ToString();
                     pData.Isocode = dr.Tables[0].Rows[i]["ISO_CODE"].ToString();
@@ -3724,7 +3726,8 @@ currencyConvert(invoiceOpen * MultiplierAP, C_Currency_ID, " + _C_Currency_ID + 
                     pData.DocBaseType = dr.Tables[0].Rows[i]["docbasetype"].ToString();
                     pData.AppliedAmt = dr.Tables[0].Rows[i]["APPLIEDAMT"].ToString();
                     pData.C_InvoicePaySchedule_ID = dr.Tables[0].Rows[i]["C_InvoicePaySchedule_ID"].ToString();
-                    pData.InvoiceScheduleDate = dr.Tables[0].Rows[i]["Scheduledate"].ToString();
+                    // Converted into DateTime to handle in Central America TimeZone.
+                    pData.InvoiceScheduleDate = Util.GetValueOfDateTime(dr.Tables[0].Rows[i]["Scheduledate"]);
                     pData.C_ConversionType_ID = Util.GetValueOfInt(dr.Tables[0].Rows[i]["C_CONVERSIONTYPE_ID"]);
                     pData.ConversionName = Util.GetValueOfString(dr.Tables[0].Rows[i]["CONVERSIONNAME"]);
                     pData.DATEACCT = Util.GetValueOfDateTime(dr.Tables[0].Rows[i]["DATEACCT"]);
@@ -5874,7 +5877,7 @@ currencyConvert(invoiceOpen * MultiplierAP, C_Currency_ID, " + _C_Currency_ID + 
         public class VIS_InvoiceData
         {
             public string SelectRow { get; set; }
-            public string Date1 { get; set; }
+            public DateTime? Date1 { get; set; }
             public string Documentno { get; set; }
             public string CinvoiceID { get; set; }
             public string Isocode { get; set; }
@@ -5887,7 +5890,7 @@ currencyConvert(invoiceOpen * MultiplierAP, C_Currency_ID, " + _C_Currency_ID + 
             public string Writeoff { get; set; }
             public string AppliedAmt { get; set; }
             public string C_InvoicePaySchedule_ID { get; set; }
-            public string InvoiceScheduleDate { get; set; }
+            public DateTime? InvoiceScheduleDate { get; set; }
             public int InvoiceRecord { get; set; }
             public int C_ConversionType_ID { get; set; }
             public string ConversionName { get; set; }
@@ -5899,7 +5902,7 @@ currencyConvert(invoiceOpen * MultiplierAP, C_Currency_ID, " + _C_Currency_ID + 
         public class VIS_PaymentData
         {
             public string SelectRow { get; set; }
-            public string Date1 { get; set; }
+            public DateTime? Date1 { get; set; }
             public string Documentno { get; set; }
             public string CpaymentID { get; set; }
             public string Isocode { get; set; }

--- a/VIS/Areas/VIS/Scripts/app/forms/vallocation.js
+++ b/VIS/Areas/VIS/Scripts/app/forms/vallocation.js
@@ -573,7 +573,9 @@
                         VIS.ADialog.info("", true, VIS.Msg.getMsg("InvalidDateFormat"), "");
                         return false;
                     }
-                    if (new Date($date.val()) < maxDate) {
+                    //Handled in Central America Time Zone.
+                    //if (new Date($date.val()) < maxDate) {
+                    if ($date.val() < Globalize.format(new Date(maxDate), "yyyy-MM-dd")) {
                         VIS.ADialog.info("", true, VIS.Msg.getMsg("SelectMaxDate") + Globalize.format(new Date(maxDate), "yyyy-MM-dd"), "");
                         $date.val(Globalize.format(new Date(maxDate), "yyyy-MM-dd"));
                         return false;


### PR DESCRIPTION
1. Handled Void AR Receipt Payment with  VA026_TRLoanApplication_ID>0 then clear the field in TR Loan Application window.

2. Date1 Value is showing on the Payment Allocation form grid is handled in Central America TimeZone for Payment allocation form.