### PR TITLE
Done below points:

### DIFF
--- a/ModelLibrary/Model/MBankStatementLine.cs
+++ b/ModelLibrary/Model/MBankStatementLine.cs
@@ -114,6 +114,70 @@ namespace VAdvantage.Model
         }
 
         /// <summary>
+        /// Set Statement Line 
+        /// </summary>
+        /// <param name="payment">Payment</param>
+        /// <returns>Message</returns>
+        public string SetPayments(MPayment payment)
+        {
+            SetC_Payment_ID(payment.GetC_Payment_ID());
+            //SetC_Currency_ID(payment.GetC_Currency_ID());
+            Decimal amt = payment.GetPayAmt(true);
+            //Currency Conversion to BankStatementLine Currency
+            if (GetC_Currency_ID() != payment.GetC_Currency_ID())
+            {
+                int conversionType = Get_ColumnIndex("C_ConversionType_ID") > 0 ? Get_ValueAsInt("C_ConversionType_ID") : payment.GetC_ConversionType_ID();
+                amt = MConversionRate.Convert(GetCtx(), amt, payment.GetC_Currency_ID(), GetC_Currency_ID(), GetValutaDate(), conversionType, GetAD_Client_ID(), GetAD_Org_ID());
+            }
+            if (amt != 0)
+            {
+                SetTrxAmt(amt);
+                if (GetStmtAmt() == 0)
+                {
+                    SetStmtAmt(amt);
+                }
+                else // Incase of Uncociled StatementLine have existing Amount
+                {
+                    decimal _diffAmt = GetStmtAmt() - GetTrxAmt();
+                    SetChargeAmt(_diffAmt - GetInterestAmt());
+                }
+                SetDescription(payment.GetDescription());
+            }
+            else 
+            {
+                return Msg.GetMsg(GetCtx(), "NoCurrencyConversion");
+            }
+            //Set VA012_VoucherType
+            if (Env.IsModuleInstalled("VA012_"))
+            {
+                bool _IsPaymentAllocate = false;
+                int _InvCount;
+                //When Payment have Multiple InvoicePaySchedules
+                if (payment.Get_ColumnIndex("IsPaymentAllocate") > 0) 
+                {
+                    _IsPaymentAllocate = Util.GetValueOfBool(payment.Get_Value("IsPaymentAllocate"));
+                }
+                if (_IsPaymentAllocate)
+                {
+                    _InvCount = Util.GetValueOfInt(DB.ExecuteScalar("SELECT COUNT(C_PaymentAllocate_ID) FROM C_PaymentAllocate WHERE IsActive='Y' AND C_Payment_ID=" + payment.GetC_Payment_ID(), null, null));
+                }
+                else 
+                {
+                    _InvCount = payment.GetC_Invoice_ID();
+                }
+                if (_InvCount > 0 || payment.GetC_Order_ID() > 0)
+                {
+                    SetVA012_VoucherType("M");
+                }
+                else if (payment.GetC_Charge_ID() > 0)
+                {
+                    SetVA012_VoucherType("V");
+                }
+            }
+            return "";
+        }
+
+        /// <summary>
         /// Add to Description
         /// </summary>
         /// <param name="description">text</param>

--- a/ModelLibrary/Model/MBankStatementLine.cs
+++ b/ModelLibrary/Model/MBankStatementLine.cs
@@ -167,11 +167,11 @@ namespace VAdvantage.Model
                 }
                 if (_InvCount > 0 || payment.GetC_Order_ID() > 0)
                 {
-                    SetVA012_VoucherType("M");
+                    SetVA012_VoucherType("M"); // 'M' indicates VA012_VoucherType as Payment
                 }
                 else if (payment.GetC_Charge_ID() > 0)
                 {
-                    SetVA012_VoucherType("V");
+                    SetVA012_VoucherType("V"); // 'V' indicates VA012_VoucherType as Voucher
                 }
             }
             return "";

--- a/ModelLibrary/Process/BankStatementPayment.cs
+++ b/ModelLibrary/Process/BankStatementPayment.cs
@@ -29,7 +29,8 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
 {
     public class BankStatementPayment : ProcessEngine.SvrProcess
     {
-
+        //Used to return error message while Creating Payment
+        private string _message;
         /// <summary>
         /// Prepare - e.g., get Parameters.
         /// </summary>
@@ -96,7 +97,7 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
             MPayment payment = CreatePayment(ibs.GetC_Invoice_ID(), ibs.GetC_BPartner_ID(),
                 ibs.GetC_Currency_ID(), ibs.GetStmtAmt(), ibs.GetTrxAmt(),
                 ibs.GetC_BankAccount_ID(),Utility.Util.GetValueOfDateTime(ibs.GetStatementLineDate() == null ? ibs.GetStatementDate() : ibs.GetStatementLineDate()),
-                Utility.Util.GetValueOfDateTime(ibs.GetDateAcct()), ibs.GetDescription(), ibs.GetAD_Org_ID());
+                Utility.Util.GetValueOfDateTime(ibs.GetDateAcct()), ibs.GetDescription(), ibs.GetAD_Org_ID(), 0, 0); //Used Zero's as parameters to Avoid throw Error
             if (payment == null)
             {
                 throw new SystemException("Could not create Payment");
@@ -134,24 +135,55 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
             //
             MBankStatement bs = new MBankStatement(GetCtx(), bsl.GetC_BankStatement_ID(), Get_Trx());
             //
+            //Check the Column Exists or not then Pass the Colums as parameters for CreatePayment method
+            int conversionType = bsl.Get_ColumnIndex("C_ConversionType_ID") > 0 ? bsl.Get_ValueAsInt("C_ConversionType_ID") : 0;
+            int _order_Id = bsl.Get_ColumnIndex("C_Order_ID") > 0 ? bsl.Get_ValueAsInt("C_Order_ID") : 0;
+
             MPayment payment = CreatePayment(bsl.GetC_Invoice_ID(), bsl.GetC_BPartner_ID(),
                 bsl.GetC_Currency_ID(), bsl.GetStmtAmt(), bsl.GetTrxAmt(),
                 bs.GetC_BankAccount_ID(), bsl.GetStatementLineDate(), bsl.GetDateAcct(),
-                bsl.GetDescription(), bsl.GetAD_Org_ID());
-            if (payment == null)
+                bsl.GetDescription(), bsl.GetAD_Org_ID(), conversionType, _order_Id);
+ 
+            if (payment == null && !string.IsNullOrEmpty(_message))
             {
-                throw new SystemException("Could not create Payment");
+                return _message;
             }
-            //	update statement
-            bsl.SetPayment(payment);
-            bsl.Save();
-            //
-            String retString = "@C_Payment_ID@ = " + payment.GetDocumentNo();
-            if (Env.Signum(payment.GetOverUnderAmt()) != 0)
+            //Update Bank StatementLine
+            _message = bsl.SetPayments(payment);
+            if (string.IsNullOrEmpty(_message))
             {
-                retString += " - @OverUnderAmt@=" + payment.GetOverUnderAmt();
+                if (!bsl.Save(Get_Trx()))
+                {
+                    Get_Trx().Rollback();
+                    ValueNamePair pp = VLogger.RetrieveError();
+                    string error = pp != null ? pp.GetValue() : "";
+                    if (string.IsNullOrEmpty(error))
+                    {
+                        error = pp != null ? pp.GetName() : "";
+                        if (string.IsNullOrEmpty(error))
+                        {
+                            error = pp != null ? pp.ToString() : "";
+                        }
+                    }
+                    return !string.IsNullOrEmpty(error) ? error : "DatanotSaved";
+                }
+                else 
+                {
+                    String retString = "@C_Payment_ID@ = " + payment.GetDocumentNo();
+                    if (Env.Signum(payment.GetOverUnderAmt()) != 0)
+                    {
+                        retString += " - @OverUnderAmt@=" + payment.GetOverUnderAmt();
+                    }
+                    Get_Trx().Commit();
+                    return retString;
+                }
+                
             }
-            return retString;
+            else 
+            {
+                Get_Trx().Rollback();
+                return _message;
+            }
         }
 
 
@@ -161,18 +193,20 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
         /// <param name="C_Invoice_ID">invoice</param>
         /// <param name="C_BPartner_ID">partner ignored when invoice exists</param>
         /// <param name="C_Currency_ID">currency</param>
-        /// <param name="StmtAmt">statement amount</param>
-        /// <param name="TrxAmt">transaction amt</param>
+        /// <param name="stmtAmt">statement amount</param>
+        /// <param name="trxAmt">transaction amt</param>
         /// <param name="C_BankAccount_ID">bank account</param>
-        /// <param name="DateTrx">transaction date</param>
-        /// <param name="DateAcct">accounting date</param>
-        /// <param name="Description">description</param>
+        /// <param name="dateTrx">transaction date</param>
+        /// <param name="dateAcct">accounting date</param>
+        /// <param name="description">description</param>
         /// <param name="AD_Org_ID"></param>
+        /// <param name="C_ConversionType_ID">C_ConversionType_ID</param>
+        /// <param name="C_Order_ID">C_Order_ID</param>
         /// <returns>payment</returns>
         private MPayment CreatePayment(int C_Invoice_ID, int C_BPartner_ID,
             int C_Currency_ID, Decimal stmtAmt, Decimal trxAmt,
             int C_BankAccount_ID, DateTime? dateTrx, DateTime? dateAcct,
-            String description, int AD_Org_ID)
+            String description, int AD_Org_ID, int C_ConversionType_ID, int C_Order_ID)
         {
             //	Trx Amount = Payment overwrites Statement Amount if defined
             Decimal payAmt = trxAmt;
@@ -180,7 +214,7 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
             {
                 payAmt = stmtAmt;
             }
-            if (C_Invoice_ID == 0 && ( Env.ZERO.CompareTo(payAmt) == 0))
+            if (C_Invoice_ID == 0 && C_Order_ID == 0 && (Env.ZERO.CompareTo(payAmt) == 0))
             {
                 throw new Exception("@PayAmt@ = 0");
             }
@@ -193,6 +227,8 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
             payment.SetAD_Org_ID(AD_Org_ID);
             payment.SetC_BankAccount_ID(C_BankAccount_ID);
             payment.SetTenderType(MPayment.TENDERTYPE_Check);
+            //Get the C_ConversionType_ID from BankStatementLine and Set C_ConversionType_ID for Payment 
+            payment.SetC_ConversionType_ID(C_ConversionType_ID);
             if (dateTrx != null)
             {
                 payment.SetDateTrx(dateTrx);
@@ -213,53 +249,223 @@ using VAdvantage.ProcessEngine;namespace VAdvantage.Process
             //
             if (C_Invoice_ID != 0)
             {
-                MInvoice invoice = new MInvoice(GetCtx(), C_Invoice_ID, null);
+                MInvoice invoice = new MInvoice(GetCtx(), C_Invoice_ID, Get_Trx());//Used Trx
                 payment.SetC_DocType_ID(invoice.IsSOTrx());		//	Receipt
-                payment.SetC_Invoice_ID(invoice.GetC_Invoice_ID());
                 payment.SetC_BPartner_ID(invoice.GetC_BPartner_ID());
-                if (Env.Signum(payAmt) != 0)	//	explicit Amount
+                //set the BPartner Location from the Invoice
+                payment.SetC_BPartner_Location_ID(invoice.GetC_BPartner_Location_ID());
+                //set the PaymentMethod by the reference of Invoice
+                payment.SetVA009_PaymentMethod_ID(invoice.GetVA009_PaymentMethod_ID());
+                payment.SetC_Currency_ID(invoice.GetC_Currency_ID());
+                decimal _dueAmt = 0;
+
+                string _sql = "SELECT * FROM C_InvoicePaySchedule WHERE VA009_PAIDAMNT IS NULL AND VA009_IsPaid = 'N' AND IsActive = 'Y' AND C_Invoice_ID =" + invoice.GetC_Invoice_ID();
+                DataSet _ds = DB.ExecuteDataset(_sql, null, Get_Trx());
+
+                if (_ds != null && _ds.Tables[0].Rows.Count == 1)
                 {
-                    payment.SetC_Currency_ID(C_Currency_ID);
+                    payment.SetC_InvoicePaySchedule_ID(Util.GetValueOfInt(_ds.Tables[0].Rows[0]["C_INVOICEPAYSCHEDULE_ID"]));
+                    _dueAmt = Util.GetValueOfDecimal(_ds.Tables[0].Rows[0]["DUEAMT"]);
+
                     if (invoice.IsSOTrx())
                     {
-                        payment.SetPayAmt(payAmt);
+                        payment.SetPayAmt(_dueAmt);
                     }
-                    else	//	payment is likely to be negative
+                    else    //	payment is likely to be negative
                     {
-                        payment.SetPayAmt(Decimal.Negate(payAmt));
+                        payment.SetPayAmt(Decimal.Negate(_dueAmt));
                     }
-                    payment.SetOverUnderAmt(Decimal.Subtract(invoice.GetGrandTotal(true), payment.GetPayAmt()));
+                    if (!payment.Save(Get_Trx()))
+                    {
+                        Get_Trx().Rollback();
+                        return null;
+                    }
                 }
-                else	// set Pay Amout from Invoice
+                else if (_ds != null && _ds.Tables[0].Rows.Count > 1)
                 {
-                    payment.SetC_Currency_ID(invoice.GetC_Currency_ID());
-                    payment.SetPayAmt(invoice.GetGrandTotal(true));
+                    if (!payment.Save(Get_Trx()))
+                    {
+                        Get_Trx().Rollback();
+                        return null;
+                    }
+                    else
+                    {
+                        for (int i = 0; i < _ds.Tables[0].Rows.Count; i++)
+                        {
+
+                            MPaymentAllocate PayAlocate = new MPaymentAllocate(GetCtx(), 0, Get_Trx());
+                            PayAlocate.SetC_Payment_ID(payment.GetC_Payment_ID());
+                            PayAlocate.SetAD_Client_ID(payment.GetAD_Client_ID());
+                            //set Organization with the reference of Bank Account
+                            PayAlocate.SetAD_Org_ID(invoice.GetAD_Org_ID());
+                            PayAlocate.SetC_Invoice_ID(invoice.GetC_Invoice_ID());
+                            PayAlocate.SetC_InvoicePaySchedule_ID(Util.GetValueOfInt(_ds.Tables[0].Rows[i]["C_INVOICEPAYSCHEDULE_ID"]));
+
+                            if (invoice.IsSOTrx())
+                            {
+                                PayAlocate.SetInvoiceAmt(Util.GetValueOfDecimal(_ds.Tables[0].Rows[i]["DUEAMT"]));
+                                PayAlocate.SetAmount(Util.GetValueOfDecimal(_ds.Tables[0].Rows[i]["DUEAMT"]));
+                            }
+                            else
+                            {
+                                PayAlocate.SetInvoiceAmt(-1 * Util.GetValueOfDecimal(_ds.Tables[0].Rows[i]["DUEAMT"]));
+                                PayAlocate.SetAmount(-1 * Util.GetValueOfDecimal(_ds.Tables[0].Rows[i]["DUEAMT"]));
+                            }
+                            if (!PayAlocate.Save(Get_Trx()))
+                            {
+                                Get_Trx().Rollback();
+                                ValueNamePair pp = VLogger.RetrieveError();
+                                string error = pp != null ? pp.GetValue() : "";
+                                if (string.IsNullOrEmpty(error))
+                                {
+                                    error = pp != null ? pp.GetName() : "";
+                                    if (string.IsNullOrEmpty(error))
+                                    {
+                                        error = pp != null ? pp.ToString() : "";
+                                    }
+                                }
+                                _message = !string.IsNullOrEmpty(error) ? error : "VA012_PaymentNotSaved";
+                                return null;
+                            }
+                            else
+                            {
+                                payment.SetPayAmt(payment.GetPayAmt() + PayAlocate.GetAmount());
+                                if (payment.Get_ColumnIndex("IsPaymentAllocate") > 0)
+                                {
+                                    payment.Set_Value("IsPaymentAllocate", true);
+                                }
+                                if (!payment.Save(Get_Trx()))
+                                {
+                                    Get_Trx().Rollback();
+                                    ValueNamePair pp = VLogger.RetrieveError();
+                                    string error = pp != null ? pp.GetValue() : "";
+                                    if (string.IsNullOrEmpty(error))
+                                    {
+                                        error = pp != null ? pp.GetName() : "";
+                                        if (string.IsNullOrEmpty(error))
+                                        {
+                                            error = pp != null ? pp.ToString() : "";
+                                        }
+                                    }
+                                    _message = !string.IsNullOrEmpty(error) ? error : "VA012_PaymentNotSaved";
+                                    return null;
+                                }
+                            }
+                        }
+                    }
                 }
             }
-            else if (C_BPartner_ID != 0)
+            else if (C_Order_ID > 0 && C_BPartner_ID > 0) // Create Payment for prePayOrder reference
             {
-                payment.SetC_BPartner_ID(C_BPartner_ID);
-                payment.SetC_Currency_ID(C_Currency_ID);
-                if (Env.Signum(payAmt) < 0)	//	Payment
+                MOrder order = new MOrder(GetCtx(), C_Order_ID, Get_Trx());
+                payment.SetC_Order_ID(C_Order_ID);
+                payment.SetC_DocType_ID(order.IsSOTrx()); //	Receipt
+                payment.SetC_BPartner_ID(order.GetC_BPartner_ID());
+
+                payment.SetC_BPartner_Location_ID(order.GetC_BPartner_Location_ID());
+                payment.SetC_Currency_ID(order.GetC_Currency_ID());
+                payment.SetVA009_PaymentMethod_ID(order.GetVA009_PaymentMethod_ID());
+                payment.SetPayAmt(order.GetGrandTotal());
+                if (!payment.Save(Get_Trx()))
                 {
-                    payment.SetPayAmt(Math.Abs(payAmt));
-                    payment.SetC_DocType_ID(false);
-                }
-                else	//	Receipt
-                {
-                    payment.SetPayAmt(payAmt);
-                    payment.SetC_DocType_ID(true);
+                    Get_Trx().Rollback();
+                    return null;
                 }
             }
             else
             {
                 return null;
             }
-            payment.Save();
-            //
-            payment.ProcessIt(MPayment.DOCACTION_Complete);
-            payment.Save();
+            //Commit the Transaction
+            Get_Trx().Commit();
+            //Call Complete Method to Complete the Record
+            //149 is AD_Process_ID for C_Payment_Process
+            _message = CompletePayment(GetCtx(), payment.GetC_Payment_ID(), 149, MPayment.DOCACTION_Complete);
+            if (!string.IsNullOrEmpty(_message))
+            {
+                return null;
+            }
             return payment;
+        }
+
+        /// <summary>
+        /// Complete the Payment Record
+        /// </summary>
+        /// <param name="ctx">Context</param>
+        /// <param name="Record_ID">C_Payment_ID</param>
+        /// <param name="Process_ID">AD_Process_ID</param>
+        /// <param name="DocAction">Documnet Action</param>
+        /// <returns>return message</returns>
+        public string CompletePayment(Ctx ctx, int Record_ID, int Process_ID, string DocAction)
+        {
+            string result = "";
+            MRole role = MRole.Get(ctx, ctx.GetAD_Role_ID());
+            if (Util.GetValueOfBool(role.GetProcessAccess(Process_ID)))
+            {
+                DB.ExecuteQuery("UPDATE C_Payment SET DocAction = '" + DocAction + "' WHERE C_Payment_ID = " + Record_ID);
+
+                MProcess proc = new MProcess(ctx, Process_ID, null);
+                MPInstance pin = new MPInstance(proc, Record_ID);
+                if (!pin.Save())
+                {
+                    ValueNamePair vnp = VLogger.RetrieveError();
+                    string errorMsg = "";
+                    if (vnp != null)
+                    {
+                        errorMsg = vnp.GetName();
+                        if (errorMsg == "")
+                            errorMsg = vnp.GetValue();
+                    }
+                    if (errorMsg == "")
+                        result = Msg.GetMsg(ctx, "DocNotCompleted");
+
+                    return result;
+                }
+
+                MPInstancePara para = new MPInstancePara(pin, 20);
+                para.setParameter("DocAction", DocAction);
+                if (!para.Save())
+                {
+                    //String msg = "No DocAction Parameter added"; // not translated
+                }
+                ProcessInfo pi = new ProcessInfo("WF", Process_ID);
+                pi.SetAD_User_ID(ctx.GetAD_User_ID());
+                pi.SetAD_Client_ID(ctx.GetAD_Client_ID());
+                pi.SetAD_PInstance_ID(pin.GetAD_PInstance_ID());
+                pi.SetRecord_ID(Record_ID);
+                pi.SetTable_ID(335); //AD_Table_ID=335 for C_Payment
+
+                ProcessCtl worker = new ProcessCtl(ctx, null, pi, null);
+                worker.Run();
+
+                if (pi.IsError())
+                {
+                    ValueNamePair vnp = VLogger.RetrieveError();
+                    string errorMsg = "";
+                    if (vnp != null)
+                    {
+                        errorMsg = vnp.GetName();
+                        if (errorMsg == "")
+                            errorMsg = vnp.GetValue();
+                    }
+
+                    if (errorMsg == "")
+                        errorMsg = pi.GetSummary();
+
+                    if (errorMsg == "")
+                        errorMsg = Msg.GetMsg(ctx, "DocNotCompleted");
+                    result = errorMsg;
+                    return result;
+                }
+                else
+                    result = "";
+            }
+            else
+            {
+                result = Msg.GetMsg(ctx, "NoAccess");
+                return result;
+            }
+            return result;
         }
     }
 }

--- a/VIS/Areas/VIS/Models/Callouts/MBankStatementModel.cs
+++ b/VIS/Areas/VIS/Models/Callouts/MBankStatementModel.cs
@@ -32,10 +32,10 @@ namespace VIS.Models
         /// <summary>
         /// Get Payment Detail
         /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="fields"></param>
-        /// <returns></returns>
-        public Decimal GetPayment(Ctx ctx, string fields)
+        /// <param name="ctx">Context</param>
+        /// <param name="fields">Tab fields</param>
+        /// <returns>List of Payment Details</returns>
+        public List<Dictionary<string, Object>> GetPayment(Ctx ctx, string fields)
         {
             string[] paramValue = fields.Split(',');
             //Assign parameter value
@@ -45,6 +45,7 @@ namespace VIS.Models
             DateTime? convDate = Util.GetValueOfDateTime(paramValue[2]);
             Decimal rate = 0;
             //End Assign parameter value
+            List<Dictionary<string, Object>> _paymentDetails = null;
 
             string qry = "SELECT PayAmt, C_Currency_ID, C_ConversionType_ID, DateAcct FROM C_Payment_v WHERE C_Payment_ID=" + c_payment_ID;
             DataSet ds = DB.ExecuteDataset(qry, null, null);
@@ -53,12 +54,18 @@ namespace VIS.Models
                 decimal payAmt = Util.GetValueOfDecimal(ds.Tables[0].Rows[0][0]);
                 int c_currency_ID = Util.GetValueOfInt(ds.Tables[0].Rows[0][1]);
                 int c_conversionType_ID = Util.GetValueOfInt(ds.Tables[0].Rows[0][2]);
-                //DateTime? dateAcct = Util.GetValueOfDateTime(ds.Tables[0].Rows[0][3]);          // JID_0333: Currency conversion should be based on Payment Account Date and Currency type
+                DateTime? dateAcct = Util.GetValueOfDateTime(ds.Tables[0].Rows[0][3]);          // JID_0333: Currency conversion should be based on Payment Account Date and Currency type
                 //rate = MConversionRate.Convert(ctx, payAmt, c_currency_ID, CurTo_ID, dateAcct, c_conversionType_ID, ctx.GetAD_Client_ID(), ctx.GetAD_Org_ID());
-                // Conversion Rate should be based on StatementLine Date Requirement by Ranvir
+                // Conversion Rate should be based on StatementLine Date & StatementLine ConversionType_ID Requirement by Ranvir
                 rate = MConversionRate.Convert(ctx, payAmt, c_currency_ID, CurTo_ID, convDate, c_conversionType_ID, ctx.GetAD_Client_ID(), ctx.GetAD_Org_ID());
+                Dictionary<string, Object> _list = new Dictionary<string, object>();
+                _list.Add("C_ConversionType_ID", c_conversionType_ID);
+                _list.Add("DateAcct", dateAcct);
+                _list.Add("payAmt", rate);
+                _paymentDetails = new List<Dictionary<string, object>>();
+                _paymentDetails.Add(_list);
             }
-            return rate;
+            return _paymentDetails;
         }
 
 

--- a/VIS/Areas/VIS/Scripts/model/callouts.js
+++ b/VIS/Areas/VIS/Scripts/model/callouts.js
@@ -5519,7 +5519,7 @@
 
         //JID_0084: if the Payment currency is different from the bank statement currency it will add the converted amount based in the currency conversion available for selected date.
         var C_Currency_ID = mTab.getValue("C_Currency_ID");
-        var statementDate = mTab.getValue("ValutaDate");
+        var statementDate = mTab.getValue("ValutaDate"); 
 
         // JID_1418: When select payment on Bank statement line, system gives an error meassage
         if (statementDate == null) {
@@ -5532,11 +5532,18 @@
         try {
             var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + statementDate.toString();
             var payAmt = VIS.dataContext.getJSONRecord("MBankStatement/GetPayment", paramStr);
-            mTab.setValue("TrxAmt", payAmt);
-            if (stmt == 0) {
-                mTab.setValue("StmtAmt", payAmt);
+            //Update the BankStatementLine fields
+            if (payAmt != null && payAmt.length > 0) {
+                mTab.setValue("TrxAmt", payAmt[0]["payAmt"]);
+                if (stmt == 0) {
+                    mTab.setValue("StmtAmt", payAmt[0]["payAmt"]);
+                }
+                //to Avoid Exception if Column not exists Used findColumn()
+                if (mTab.findColumn("C_ConversionType_ID") >= 0) {
+                    mTab.setValue("C_ConversionType_ID", payAmt[0]["C_ConversionType_ID"]);
+                }
+                mTab.setValue("DateAcct", new Date(payAmt[0]["DateAcct"]));
             }
-
             //param[0] = new VIS.DB.SqlParam("@C_Payment_ID", C_Payment_ID);
             //dr = VIS.DB.executeReader(sql, param, null);
             //if (dr.read())/// if (rs.next())
@@ -5582,7 +5589,7 @@
         //}
 
         var C_Currency_ID = mTab.getValue("C_Currency_ID");
-        var acctDate = mTab.getValue("DateAcct");
+        var acctDate = mTab.getValue("ValutaDate");
 
         try {
             var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + acctDate.toString();


### PR DESCRIPTION
1.Add Currency Rate Type Field on the Bank Statement Line and this field will be UI Mandatory.  

2.On the Statement Line, when payment Id reference is present then currency rate type should be same as on the Payment window. 

3.On the Statement Line, when Payment ID Reference is present then Currency Rate type field will be read only. 

4.On the Statement Line when we select Payment then the system will set same account date as on the Payment window.  

          Note: At the time of changing statement date it should Change the Account date. 

5.On the Statement Line when Invoice ID reference is present then Payment will generate with Currency Rate type bind on the line. 

6.On the Statement Line when Invoice ID Reference is present then payment will generate with Invoice Currency. 

 7.On the Statement Line when Order ID reference is present then Payment will generate with Currency Rate type bind on the Line. 

8.On the Statement Line when Order ID reference is present then payment will generate with Order Currency. 