### PR TITLE
1. Show the Validation message when user selected Payment Without sel…

### DIFF
--- a/ModelLibrary/Model/MBankStatementLine.cs
+++ b/ModelLibrary/Model/MBankStatementLine.cs
@@ -428,6 +428,14 @@ namespace VAdvantage.Model
                 MInvoice invoice = new MInvoice(GetCtx(), GetC_Invoice_ID(), Get_TrxName());
                 SetC_BPartner_ID(invoice.GetC_BPartner_ID());
             }
+            //Set BPartner_ID when having Order_ID
+            if (Env.IsModuleInstalled("VA012_")) {
+                if (GetC_Order_ID() != 0 && GetC_BPartner_ID() == 0)
+                {
+                    int _bpartner_ID = Util.GetValueOfInt(DB.ExecuteScalar("SELECT C_BPartner_ID FROM C_Order WHERE IsActive='Y' AND C_Order_ID=" + GetC_Order_ID(), null, Get_Trx()));
+                    SetC_BPartner_ID(_bpartner_ID);
+                }
+            }
             //	Calculate Charge = Statement - trx - Interest  
             Decimal amt = GetStmtAmt();
             amt = Decimal.Subtract(amt, GetTrxAmt());

--- a/ModelLibrary/Model/MPayment.cs
+++ b/ModelLibrary/Model/MPayment.cs
@@ -5177,8 +5177,9 @@ namespace VAdvantage.Model
 
                     if (GetC_Payment_ID() > 0)
                     {
-                        DB.ExecuteQuery(" UPDATE C_BankStatementLine bsl SET bsl.C_Payment_ID = null WHERE" +
-                            " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus IN('DR', 'IP')) " +
+                        //changed DocStatus Condition
+                        DB.ExecuteQuery("UPDATE C_BankStatementLine bsl SET bsl.C_Payment_ID = null WHERE" +
+                            " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus NOT IN('CO', 'CL', 'RE', 'VO')) " +
                             "AND bsl.C_Payment_ID = " + GetC_Payment_ID(), null, Get_Trx());
                     }
                 }
@@ -5466,8 +5467,9 @@ namespace VAdvantage.Model
 
                 if (GetC_Payment_ID() > 0)
                 {
+                    //changed DocStatus Condition
                     DB.ExecuteQuery(" UPDATE C_BankStatementLine bsl SET bsl.C_Payment_ID = null WHERE" +
-                        " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus IN('DR', 'IP')) " +
+                        " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus NOT IN('CO', 'CL', 'RE', 'VO')) " +
                         "AND bsl.C_Payment_ID = " + GetC_Payment_ID(), null, Get_Trx());
                 }
             }

--- a/ModelLibrary/Model/MPayment.cs
+++ b/ModelLibrary/Model/MPayment.cs
@@ -5171,6 +5171,18 @@ namespace VAdvantage.Model
                     }
                 }
 
+                //Remove Payment reference on Bank statement Line
+                if (Env.IsModuleInstalled("VA012_"))
+                {
+
+                    if (GetC_Payment_ID() > 0)
+                    {
+                        DB.ExecuteQuery(" UPDATE C_BankStatementLine bsl SET bsl.C_Payment_ID = null WHERE" +
+                            " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus IN('DR', 'IP')) " +
+                            "AND bsl.C_Payment_ID = " + GetC_Payment_ID(), null, Get_Trx());
+                    }
+                }
+
                 //	Unlink & De-Allocate
                 DeAllocate();
             }
@@ -5445,6 +5457,18 @@ namespace VAdvantage.Model
                 {
                     DB.ExecuteQuery("UPDATE VA026_TRLoanApplication SET  C_Payment_ID = null WHERE C_Payment_ID = " + GetC_Payment_ID() +
                                     @" AND VA026_TRLoanApplication_ID = " + Get_ValueAsInt("VA026_TRLoanApplication_ID"), null, null);
+                }
+            }
+
+            //Remove Payment reference on Bank statement Line
+            if (Env.IsModuleInstalled("VA012_"))
+            {
+
+                if (GetC_Payment_ID() > 0)
+                {
+                    DB.ExecuteQuery(" UPDATE C_BankStatementLine bsl SET bsl.C_Payment_ID = null WHERE" +
+                        " EXISTS(SELECT * FROM C_BankStatement bs WHERE bsl.C_BankStatement_ID = bs.C_BankStatement_ID  AND bs.DocStatus IN('DR', 'IP')) " +
+                        "AND bsl.C_Payment_ID = " + GetC_Payment_ID(), null, Get_Trx());
                 }
             }
 

--- a/VIS/Areas/VIS/Scripts/app/calloutengine.js
+++ b/VIS/Areas/VIS/Scripts/app/calloutengine.js
@@ -112,7 +112,23 @@
         //if (value == null || !(value.getType() == typeof(DateTime)))
         if (!value)
             return "";
-        mTab.setValue("DateAcct", value);
+        //Incase of Bank statement Line can't update the DateAcct when C_Payment_ID is present
+        if (mTab.getTableName() == "C_BankStatementLine") {
+            //Can't update the DateAcct when C_CashLine_ID is present
+            if (mTab.findColumn("C_CashLine_ID") >= 0) {
+                if (VIS.Utility.Util.getValueOfInt(mTab.getValue("C_Payment_ID")) <= 0 && VIS.Utility.Util.getValueOfInt(mTab.getValue("C_CashLine_ID")) <= 0) {
+                    mTab.setValue("DateAcct", value);
+                }
+            }
+            else {
+                if (VIS.Utility.Util.getValueOfInt(mTab.getValue("C_Payment_ID")) <= 0) {
+                    mTab.setValue("DateAcct", value);
+                }
+            }
+        }
+        else {
+            mTab.setValue("DateAcct", value);
+        }
 
         // JID_1332: Set Value in Effective Date on selection of Statement date.
         if (mTab.getTableName() == "C_BankStatementLine") {

--- a/VIS/Areas/VIS/Scripts/model/callouts.js
+++ b/VIS/Areas/VIS/Scripts/model/callouts.js
@@ -5522,15 +5522,19 @@
         var statementDate = mTab.getValue("ValutaDate"); 
 
         // JID_1418: When select payment on Bank statement line, system gives an error meassage
+        //When select payment on Bank statement line with out select the statmenet Date, return error meassage
         if (statementDate == null) {
-            statementDate = new Date();
+            //statementDate = new Date();
+            mTab.setValue("C_Payment_ID", 0);
+            return VIS.Msg.getMsg("PlzSelectStmtDate");
         }
 
         //var sql = "SELECT PayAmt FROM C_Payment_v WHERE C_Payment_ID=@C_Payment_ID";		//	1
         //var dr = null;
         //var param = [];
         try {
-            var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + statementDate.toString();
+            //passed statement Date as in JSON format
+            var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + JSON.stringify(statementDate);
             var payAmt = VIS.dataContext.getJSONRecord("MBankStatement/GetPayment", paramStr);
             //Update the BankStatementLine fields
             if (payAmt != null && payAmt.length > 0) {
@@ -5590,6 +5594,10 @@
 
         var C_Currency_ID = mTab.getValue("C_Currency_ID");
         var acctDate = mTab.getValue("ValutaDate");
+        //When select payment on Bank statement line, system gives an error meassage
+        if (acctDate == null) {
+            return VIS.Msg.getMsg("PlzSelectStmtDate");
+        }
 
         try {
             var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + acctDate.toString();


### PR DESCRIPTION
1. Show the Validation message when user selected Payment Without selecting StatementLine Date on Bank Statement Line.

2. When Payment or CashLine is selected or Created Payment on Bank Statement Line after that user can't able to update the DateAcct if change the StatementLine Date.
3. When User Void or Reverse the Payment then It will clear the Payment reference on Bank Statement Line if Bank Statement is Drafted or InProgress.
4. When User select the Order reference and Save the Record  on Bank Statement Line then It will update the Business Partner on Bank Statement Line.