### PR TITLE
1. AcctDate is not updating if Payment or CashLine reference is there…

### DIFF
--- a/VIS/Areas/VIS/Models/Callouts/MBankStatementModel.cs
+++ b/VIS/Areas/VIS/Models/Callouts/MBankStatementModel.cs
@@ -43,6 +43,8 @@ namespace VIS.Models
             int CurTo_ID = Util.GetValueOfInt(paramValue[1]);
             //Conversion based on Bank StatementLine Date
             DateTime? convDate = Util.GetValueOfDateTime(paramValue[2]);
+            //Get the Org_ID from the StatementLine - Tab
+            int ad_org_ID = Util.GetValueOfInt(paramValue[3]);
             Decimal rate = 0;
             //End Assign parameter value
             List<Dictionary<string, Object>> _paymentDetails = null;
@@ -58,7 +60,14 @@ namespace VIS.Models
                 //DateTime? dateAcct = Util.GetValueOfDateTime(ds.Tables[0].Rows[0][3]);          // JID_0333: Currency conversion should be based on Payment Account Date and Currency type
                 //rate = MConversionRate.Convert(ctx, payAmt, c_currency_ID, CurTo_ID, dateAcct, c_conversionType_ID, ctx.GetAD_Client_ID(), ctx.GetAD_Org_ID());
                 // Conversion Rate should be based on StatementLine Date & StatementLine ConversionType_ID Requirement by Ranvir
-                rate = MConversionRate.Convert(ctx, payAmt, c_currency_ID, CurTo_ID, convDate, c_conversionType_ID, ctx.GetAD_Client_ID(), ctx.GetAD_Org_ID());
+                if (CurTo_ID != c_currency_ID)
+                {
+                    rate = MConversionRate.Convert(ctx, payAmt, c_currency_ID, CurTo_ID, convDate, c_conversionType_ID, ctx.GetAD_Client_ID(), ad_org_ID);
+                }
+                else
+                {
+                    rate = payAmt;
+                }
                 Dictionary<string, Object> _list = new Dictionary<string, object>();
                 _list.Add("C_ConversionType_ID", c_conversionType_ID);
                 //_list.Add("DateAcct", dateAcct);

--- a/VIS/Areas/VIS/Scripts/app/calloutengine.js
+++ b/VIS/Areas/VIS/Scripts/app/calloutengine.js
@@ -113,7 +113,7 @@
         if (!value)
             return "";
         //Incase of Bank statement Line can't update the DateAcct when C_Payment_ID is present
-        if (mTab.getTableName() == "C_BankStatementLine") {
+        //if (mTab.getTableName() == "C_BankStatementLine") {
             //Can't update the DateAcct when C_CashLine_ID is present
             //if (mTab.findColumn("C_CashLine_ID") >= 0) {
             //    if (VIS.Utility.Util.getValueOfInt(mTab.getValue("C_Payment_ID")) <= 0 && VIS.Utility.Util.getValueOfInt(mTab.getValue("C_CashLine_ID")) <= 0) {
@@ -125,11 +125,12 @@
             //        mTab.setValue("DateAcct", value);
             //    }
             //}
-            mTab.setValue("DateAcct", value);
-        }
-        else {
-            mTab.setValue("DateAcct", value);
-        }
+        //    mTab.setValue("DateAcct", value);
+        //}
+        //else {
+        //Can be change according to Statement Line Date incase of BankStatement window
+        mTab.setValue("DateAcct", value);
+        //}
 
         // JID_1332: Set Value in Effective Date on selection of Statement date.
         if (mTab.getTableName() == "C_BankStatementLine") {

--- a/VIS/Areas/VIS/Scripts/model/callouts.js
+++ b/VIS/Areas/VIS/Scripts/model/callouts.js
@@ -5557,6 +5557,8 @@
             if (mTab.findColumn("C_ConversionType_ID") >= 0) {
                 mTab.setValue("C_ConversionType_ID", 0);
             }
+            //setCalloutActive as false
+            this.setCalloutActive(false);
             return "";
         }
 
@@ -5574,6 +5576,8 @@
             if (mTab.findColumn("C_ConversionType_ID") >= 0) {
                 mTab.setValue("C_ConversionType_ID", 0);
             }
+            //setCalloutActive as false
+            this.setCalloutActive(false);
             return "";
         }
         //
@@ -5585,6 +5589,8 @@
         //JID_0084: if the Payment currency is different from the bank statement currency it will add the converted amount based in the currency conversion available for selected date.
         var C_Currency_ID = mTab.getValue("C_Currency_ID");
         var statementDate = mTab.getValue("DateAcct"); /*ValutaDate*/
+        //Get the Org_ID from the StatementLine - Tab
+        var org_Id = mTab.getValue("AD_Org_ID");
 
         // JID_1418: When select payment on Bank statement line, system gives an error meassage
         //When select payment on Bank statement line with out select the statmenet Date, return error meassage
@@ -5599,8 +5605,8 @@
         //var dr = null;
         //var param = [];
         try {
-            //passed statement Date as in JSON format
-            var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + statementDate;//JSON.stringify(statementDate)
+            //passed statement Date, Org_ID as in JSON format
+            var paramStr = C_Payment_ID.toString() + "," + C_Currency_ID.toString() + "," + statementDate + "," + org_Id.toString();//JSON.stringify(statementDate)
             var payAmt = VIS.dataContext.getJSONRecord("MBankStatement/GetPayment", paramStr);
             //Update the BankStatementLine fields
             if (payAmt != null && payAmt.length > 0) {


### PR DESCRIPTION
1. AcctDate is not updating if Payment or CashLine reference is there on BankStatement Line when change the statementLine Date.

2. Amount should convert based on Selected Organization on the Line not the Context Organization.
above issue's are fixed.