### PR TITLE
Done changes for JID- 1946,1957: handled Currency Conversion for manu…

### DIFF
--- a/VIS/Areas/VIS/Controllers/VPayPrintController.cs
+++ b/VIS/Areas/VIS/Controllers/VPayPrintController.cs
@@ -43,6 +43,20 @@ namespace VIS.Controllers
             return Json(JsonConvert.SerializeObject(objVPaySelect.Cmd_Print(ctx, C_PaySelection_ID, m_C_BankAccount_ID, paymentMethod_ID, Util.GetValueOfInt(checkNo))), JsonRequestBehavior.AllowGet);
         }
 
+        /// <summary>
+        /// Get DocumentNo from Payment
+        /// </summary>
+        /// <param name="paymentId">C_Payment_ID</param>
+        /// <returns>JSON Result which contains DocumentNo</returns>
+        [AjaxAuthorizeAttribute]
+        [AjaxSessionFilterAttribute]
+        public JsonResult GetDocumentNo(string paymentId)
+        {
+            Ctx ctx = Session["ctx"] as Ctx;
+            VPayPrintModel objVPaySelect = new VPayPrintModel();
+            return Json(JsonConvert.SerializeObject(objVPaySelect.GetDocumentNo(ctx, paymentId)), JsonRequestBehavior.AllowGet);
+        }
+
         [AjaxAuthorizeAttribute]
         [AjaxSessionFilterAttribute]
         [HttpPost]

--- a/VIS/Areas/VIS/Models/VPayPrintModel.cs
+++ b/VIS/Areas/VIS/Models/VPayPrintModel.cs
@@ -315,6 +315,30 @@ namespace VIS.Models
             return objCmdPrint;
 
         }
+
+        /// <summary>
+        /// Get DocumentNo from the Payment
+        /// </summary>
+        /// <param name="ctx">Context</param>
+        /// <param name="paymentId">C_Payment_ID</param>
+        /// <returns>List of Document No's</returns>
+        public List<int> GetDocumentNo(Ctx ctx, string paymentId)
+        {
+            int _documentNo = 0;
+            List<int> documentNo = new List<int>();
+            string sql = "SELECT p.DocumentNo FROM C_Payment p WHERE IsActive='Y' AND p.C_Payment_ID IN(" + paymentId + ")";
+            DataSet ds = DB.ExecuteDataset(sql, null, null);
+            if (ds != null && ds.Tables[0].Rows.Count > 0)
+            {
+                for (int i = 0; i < ds.Tables[0].Rows.Count; i++)
+                {
+                    _documentNo = Util.GetValueOfInt(ds.Tables[0].Rows[i]["DocumentNo"]);
+                    documentNo.Add(_documentNo);
+                }
+            }
+            return documentNo;
+        }
+
         /// <summary>
         /// ContinueCheckPrint
         /// </summary>

--- a/VIS/Areas/VIS/Scripts/app/Framework/parameterdialog.js
+++ b/VIS/Areas/VIS/Scripts/app/Framework/parameterdialog.js
@@ -385,11 +385,13 @@
 
             var dependentFields = this.getDependantFields(columnName);
             for (var i = 0, len = dependentFields.length; i < len; i++) {
-                var dep = field;
+                //var dep = field;
+                //field is not defined
+                var dep = dependentFields[i];
                 if (dep == null)
                     continue;
                 dep.refreshLookup();
-                dep.setValue(dep.getDefault(Env.getCtx(), this.windowNo), true);
+                dep.setValue(dep.getDefault(VIS.Env.getCtx(), this.windowNo), true);
             }
         }
     };

--- a/VIS/Areas/VIS/Scripts/app/forms/vpayprint.js
+++ b/VIS/Areas/VIS/Scripts/app/forms/vpayprint.js
@@ -393,7 +393,11 @@
                     isBusy(false);
                     var data = JSON.parse(jsonResult);
                     if (data != null || data != undefined) {
-                        VIS.ADialog.confirm("VPayPrintPrintRemittance?", true, "", "Confirm", function (result) {
+                        //get documenNo's
+                        var paymentId = data.join();
+                        var _docNo = getDocumentNo(paymentId);
+                        _docNo != null ? " Payment Created - " + _docNo : _docNo;
+                        VIS.ADialog.confirm("VPayPrintPrintRemittance?", true, _docNo, "Confirm", function (result) {
                             if (result) {
                                 isBusy(true);
                                 window.setTimeout(function () {
@@ -412,6 +416,27 @@
                 }
             });
         };
+
+        //Get the DocumentNo's for Payment
+        function getDocumentNo(_paymentId) {
+            var _docId = null;
+            $.ajax({
+                url: VIS.Application.contextUrl + "VPayPrint/GetDocumentNo",
+                async: false,
+                datatype: "Json",
+                type: "GET",
+                contentType: 'application/json; charset=utf-8',
+                data: { paymentId: _paymentId },
+                success: function (data) {
+                    _docId = JSON.parse(data);
+                    _docId = _docId != null ? _docId.join() : _docId;
+                },
+                error: function (e) {
+                    console.log(e);
+                }
+            });
+            return _docId;
+        }
         //******************
         //VPayPrintPrintRemittance
         //******************$self.windowNo

--- a/VIS/Areas/VIS/Scripts/app/forms/vpayprint.js
+++ b/VIS/Areas/VIS/Scripts/app/forms/vpayprint.js
@@ -396,7 +396,8 @@
                         //get documenNo's
                         var paymentId = data.join();
                         var _docNo = getDocumentNo(paymentId);
-                        _docNo != null ? " Payment Created - " + _docNo : _docNo;
+                        //used get Message to get Value
+                        _docNo != null ? VIS.Msg.getMsg("VIS_PaymentCreated") + _docNo : _docNo;
                         VIS.ADialog.confirm("VPayPrintPrintRemittance?", true, _docNo, "Confirm", function (result) {
                             if (result) {
                                 isBusy(true);


### PR DESCRIPTION
Done changes for JID- 1946,1957: handled Currency Conversion for manual Payment against Invoices and Orders on Payment form.
If generate manual payment then generate schedule in bank currency not invoice currency.
On Print or Export Check for Current Payables should be show the Doc No on pop-up before remittance.
System should not allow to change the Due Date Less then the Transaction Date for Split Schedule Button on Payment form.