### PR TITLE
Provisional Invoice Paid checkbox handling

### DIFF
--- a/ModelLibrary/Model/MPayment.cs
+++ b/ModelLibrary/Model/MPayment.cs
@@ -2875,6 +2875,13 @@ namespace VAdvantage.Model
                 //	MProject project = new MProject(GetCtx(), GetC_Project_ID());
             }
 
+            // Update Paid on Provisional Invoice 
+            if (Get_ColumnIndex("C_ProvisionalInvoice_ID") >= 0 && Util.GetValueOfInt(Get_Value("C_ProvisionalInvoice_ID")) > 0)
+            {
+                DB.ExecuteQuery("UPDATE C_ProvisionalInvoice SET IsPaid = " + (GetReversalDoc_ID() == 0 ? "'Y'" : "'N'") +
+                    @" WHERE C_ProvisionalInvoice_ID = " + Util.GetValueOfInt(Get_Value("C_ProvisionalInvoice_ID")), null, Get_Trx());
+            }
+
             //	Counter Doc
             MPayment counter = CreateCounterDoc();
             if (counter != null)
@@ -5333,6 +5340,12 @@ namespace VAdvantage.Model
             if (reversal.Get_ColumnIndex("TempDocumentNo") > 0)
             {
                 reversal.SetTempDocumentNo("");
+            }
+
+            // Set Provisional reference
+            if (Get_ColumnIndex("C_ProvisionalInvoice_ID") >= 0)
+            {
+                reversal.Set_Value("C_ProvisionalInvoice_ID", Get_Value("C_ProvisionalInvoice_ID"));
             }
 
             if (!reversal.Save(Get_Trx()))

--- a/ModelLibrary/Model/MProvisionalInvoice.cs
+++ b/ModelLibrary/Model/MProvisionalInvoice.cs
@@ -219,7 +219,7 @@ namespace VAdvantage.Model
                 bool isPOCostingMethod = MCostElement.IsPOCostingmethod(GetCtx(), line.GetAD_Client_ID(), product1.GetM_Product_ID(), product1.Get_Trx());
 
                 // Get Product Cost
-                Decimal ProductLineCost = line.GetProductLineCost(line , isPOCostingMethod);
+                Decimal ProductLineCost = line.GetProductLineCost(line, isPOCostingMethod);
 
                 // calculate invoice line costing after calculating costing of linked MR line 
                 if (!MCostQueue.CreateProductCostsDetails(GetCtx(), GetAD_Client_ID(), GetAD_Org_ID(), product1, line.GetM_AttributeSetInstance_ID(),
@@ -412,6 +412,14 @@ namespace VAdvantage.Model
             if (MNonBusinessDay.IsNonBusinessDay(GetCtx(), GetDateAcct(), GetAD_Org_ID()))
             {
                 _processMsg = Common.Common.NONBUSINESSDAY;
+                return false;
+            }
+
+            // if Payment Refrence exist, then no to void the record
+            if (Util.GetValueOfInt(DB.ExecuteScalar(@"SELECT COUNT(C_Payment_ID) FROM C_Payment 
+                WHERE DocStatus NOT IN ('RE', 'VO') AND C_ProvisionalInvoice_ID = " + GetC_ProvisionalInvoice_ID(), null, Get_Trx())) > 0)
+            {
+                _processMsg = Msg.GetMsg(GetCtx(), "DeletePaymentFirst");
                 return false;
             }
 

--- a/ModelLibrary/Process/ViennaAdvantageProcess/InOutCreateInvoice.cs
+++ b/ModelLibrary/Process/ViennaAdvantageProcess/InOutCreateInvoice.cs
@@ -88,6 +88,17 @@ namespace ViennaAdvantage.Process
             int count = Util.GetValueOfInt(DB.ExecuteScalar(" SELECT Count(M_Inout_ID) FROM M_Inout WHERE ISSOTRX='Y' AND M_Inout_ID=" + GetRecord_ID()));
             MInOut ship = null;
             bool isAllownonItem = Util.GetValueOfString(GetCtx().GetContext("$AllowNonItem")).Equals("Y");
+
+            // check if reference found on Provisional Invoice, then not to create Invoice
+            if (_M_InOut_ID > 0 && Util.GetValueOfInt(DB.ExecuteScalar(@"SELECT COUNT(iol.M_InOut_ID)
+                                      FROM C_ProvisionalInvoiceLine pil
+                                      INNER JOIN C_ProvisionalInvoice  pi ON (pi.C_ProvisionalInvoice_ID = pil.C_ProvisionalInvoice_ID)
+                                      LEFT JOIN M_InOutLine iol ON (iol.M_InOutLine_ID = pil.M_InOutLine_ID)
+                                      WHERE pi.DocStatus NOT IN ( 'RE', 'VO' ) AND iol.M_InOut_ID = " + _M_InOut_ID, null, Get_Trx())) > 0)
+            {
+                throw new ArgumentException(Msg.GetMsg(GetCtx() , "VIS_ProvisionalInvoiceCreated"));
+            }
+
             if (count > 0)
             {
                 if (_M_InOut_ID == 0)

--- a/VIS/Areas/VIS/Models/Callouts/MPaymentModel.cs
+++ b/VIS/Areas/VIS/Models/Callouts/MPaymentModel.cs
@@ -274,7 +274,7 @@ namespace VIS.Models
         {
             Dictionary<String, Object> retDic = null;
 
-            string sql = "SELECT C_BPartner_ID,C_BPartner_Location_ID,GrandTotal ";
+            string sql = "SELECT C_BPartner_ID,C_BPartner_Location_ID,GrandTotal, C_Currency_ID, C_ConversionType_ID ";
             if (Env.IsModuleInstalled("VA009_"))
             {
               //  sql += ", VA009_PaymentMethod_ID";
@@ -287,6 +287,8 @@ namespace VIS.Models
                 retDic["C_BPartner_ID"] = Util.GetValueOfInt(ds.Tables[0].Rows[0]["C_BPartner_ID"]);
                 retDic["C_BPartner_Location_ID"] = Util.GetValueOfInt(ds.Tables[0].Rows[0]["C_BPartner_Location_ID"]);
                 retDic["GrandTotal"] = Util.GetValueOfDecimal(ds.Tables[0].Rows[0]["GrandTotal"]);
+                retDic["C_Currency_ID"] = Util.GetValueOfInt(ds.Tables[0].Rows[0]["C_Currency_ID"]);
+                retDic["C_ConversionType_ID"] = Util.GetValueOfInt(ds.Tables[0].Rows[0]["C_ConversionType_ID"]);
                 if (Env.IsModuleInstalled("VA009_"))
                 {
                    // retDic["VA009_PaymentMethod_ID"] = Util.GetValueOfDecimal(ds.Tables[0].Rows[0]["VA009_PaymentMethod_ID"]);

--- a/VIS/Areas/VIS/Scripts/model/callouts.js
+++ b/VIS/Areas/VIS/Scripts/model/callouts.js
@@ -20078,6 +20078,8 @@
                 mTab.setValue("C_BPartner_Location_ID", data["C_BPartner_Location_ID"]);
                 mTab.setValue("PaymentAmount", data["GrandTotal"]);
                 mTab.setValue("PayAmt", data["GrandTotal"]);
+                mTab.setValue("C_Currency_ID", data["C_Currency_ID"]);
+                mTab.setValue("C_ConversionType_ID", data["C_ConversionType_ID"]);
                 //check if VA009 module is Installed 
                 var DataPrefix = VIS.dataContext.getJSONRecord("ModulePrefix/GetModulePrefix", "VA009_");
                 if (DataPrefix["VA009_"]) {


### PR DESCRIPTION
1. Need to mark paid checkbox true on Provisional Invoice when payment is created with Provisional Invoice reference. When we reverse the payment, then make it false
2. When we reverse the Provisional Invoice, and payment exist then not reverse the record